### PR TITLE
Fix layer1 choices

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,9 @@
+import napari
+from napari_math import make_math_widget
+
+viewer = napari.Viewer()
+viewer.open_sample('napari', 'cells3d')
+
+widget = make_math_widget()
+viewer.window.add_dock_widget(widget, area='bottom')
+napari.run()

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ project_urls =
     User Support = https://github.com/zacsimile/napari-math/issues
 url = https://github.com/zacsimile/napari-math
 version = 0.0.1a
-author = Zach Marin
+author = Zach Marin, Talley Lambert
 author_email = zach.marin@yale.edu
 
 license = MIT
@@ -25,6 +25,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Operating System :: OS Independent
     License :: OSI Approved :: MIT License
 

--- a/src/napari_math/_widget.py
+++ b/src/napari_math/_widget.py
@@ -38,6 +38,8 @@ def math_init(widget: FunctionGui):
     @widget.layer0.changed.connect
     def _layer0_callback(new_layer: Layer):
         widget.layer1.reset_choices()
+        widget.layer1.visible = isinstance(new_layer, Image)
+
         # Update operations
         opts = ['add', 'subtract', 'multiply', 'divide']
         if type(new_layer) == Image:

--- a/src/napari_math/_widget.py
+++ b/src/napari_math/_widget.py
@@ -97,7 +97,7 @@ def make_math_widget(layer0: Layer,
     layer0_name = layer0._source.path if layer0._source.path is not None else layer0.name
     md = {"layer0": layer0_name, "operation": operation, "scalar": scalar}
 
-    if layer1:
+    if not layer1:
         # If we're only dealing with one layer, we only need to apply the operation
         # to the scalar
         data = operation_dict.get(operation)(get_layer_data(layer0).T, scalar).T


### PR DESCRIPTION
ugly but functional fix to layer1 choices.

also added a `demo.py` file that might be useful for rapid development.

I slightly modified the magic_factory params a bit, using the `nullable` option for layer1 (instead of the `NO_LAYER` sentinel), and used `labels=False` ... which necessitated the slightly hacky `_lbl` param in the function sig.  your call if you prefer the other method of setting `'label': " "` on all the other widgets